### PR TITLE
application.jsの中身を修正

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,7 +7,6 @@ require("@rails/ujs").start()
 // require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-require('../preview')
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference


### PR DESCRIPTION
・デプロイ時にエラーが起きた原因を特定。存在しないファイルを指定していたため、こちらを削除。